### PR TITLE
目的地と出発地が入れ替えれないときがある

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -84,7 +84,7 @@ export default function Home() {
           })
 
           if (data && !error) {
-            const displayBuses = generateDisplayBuses(data, group.id, null)
+            const displayBuses = generateDisplayBuses(busStopGroups, data, null)
             results[group.id] = {
               raw: data,
               filtered: filterBusesByDeparture(displayBuses, now),

--- a/apps/web/app/(app)/timetable/page.tsx
+++ b/apps/web/app/(app)/timetable/page.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { TimetableDisplay } from '@/components/timetable/timetable-display'
-import { TimetableFilter } from '@/components/timetable/timetable-filter'
-import { client } from '@/lib/client' // clientをインポート
-import { TimeFilterType } from '@/lib/types/timetable'
-import { canSwapStations, filterTimetable } from '@/lib/utils/timetable'
-import { useCallback, useEffect, useMemo, useState, Suspense } from 'react'
-import type { operations, components } from '@/generated/oas' // operations をインポートリストに追加 (既に存在する場合あり)
-import { format, parseISO } from 'date-fns' // date-fns から format, parseISO をインポート
-import { useRouter, useSearchParams } from 'next/navigation' // URLパラメータ処理用
+import { TimetableDisplay } from '@/components/timetable/timetable-display';
+import { TimetableFilter } from '@/components/timetable/timetable-filter';
+import type { components, operations } from '@/generated/oas';
+import { client } from '@/lib/client';
+import { TimeFilterType } from '@/lib/types/timetable';
+import { canSwapStations, filterTimetable } from '@/lib/utils/timetable';
+import { format, parseISO } from 'date-fns';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 
 export default function TimetablePage() {
   return (
@@ -23,13 +23,14 @@ function TimetableContent() {
   const searchParams = useSearchParams()
 
   // 状態管理
-  const [selectedDeparture, setSelectedDeparture] = useState<number | null>(null)
-  const [selectedDestination, setSelectedDestination] = useState<number | null>(null)
+  const [selectedDepartureGroupId, setSelectedDepartureGroupId] = useState<number | null>(null)
+  const [selectedDestinationGroupId, setSelectedDestinationGroupId] = useState<number | null>(null)
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
   const [now, setNow] = useState<Date | null>(null)
   const [timeFilter, setTimeFilter] = useState<TimeFilterType>('all')
   const [startTime, setStartTime] = useState<string>('10:00')
   const [endTime, setEndTime] = useState<string>('10:00')
+  const [isLoadingTimetable, setIsLoadingTimetable] = useState(false)
   // APIからの時刻表データを保持するstate (型を修正)
   const [timetableData, setTimetableData] = useState<
     components['schemas']['Models.BusStopGroupTimetable'] | null
@@ -37,12 +38,12 @@ function TimetableContent() {
   const updateUrlParams = useCallback(() => {
     const params = new URLSearchParams()
 
-    if (selectedDeparture !== null) {
-      params.set('from', selectedDeparture.toString())
+    if (selectedDepartureGroupId !== null) {
+      params.set('from', selectedDepartureGroupId.toString())
     }
 
-    if (selectedDestination !== null) {
-      params.set('to', selectedDestination.toString())
+    if (selectedDestinationGroupId !== null) {
+      params.set('to', selectedDestinationGroupId.toString())
     }
 
     if (selectedDate !== null) {
@@ -63,7 +64,7 @@ function TimetableContent() {
 
     // URLを更新（履歴を残さない）
     router.replace(`/timetable?${params.toString()}`, { scroll: false })
-  }, [selectedDeparture, selectedDestination, selectedDate, timeFilter, startTime, endTime, router]) // URLパラメータから状態を読み込む
+  }, [selectedDepartureGroupId, selectedDestinationGroupId, selectedDate, timeFilter, startTime, endTime, router]) // URLパラメータから状態を読み込む
   useEffect(() => {
     // 両方の形式のパラメータ名に対応
     const departureParam = searchParams.get('departure') || searchParams.get('from')
@@ -74,17 +75,15 @@ function TimetableContent() {
     const startTimeParam = searchParams.get('startTime')
     const endTimeParam = searchParams.get('endTime')
 
-    // パラメータがある場合のみ状態を更新
     if (departureParam) {
-      setSelectedDeparture(Number(departureParam))
+      setSelectedDepartureGroupId(Number(departureParam))
     }
 
     if (destinationParam) {
-      setSelectedDestination(Number(destinationParam))
+      setSelectedDestinationGroupId(Number(destinationParam))
     }
 
     if (dateParam) {
-      // 日付パラメータがあれば、その日付を設定
       try {
         const parsedDate = parseISO(dateParam)
         setSelectedDate(parsedDate)
@@ -131,8 +130,8 @@ function TimetableContent() {
     if (!selectedDate) return // 初期化前は更新しない
     updateUrlParams()
   }, [
-    selectedDeparture,
-    selectedDestination,
+    selectedDepartureGroupId,
+    selectedDestinationGroupId,
     selectedDate,
     timeFilter,
     startTime,
@@ -142,72 +141,87 @@ function TimetableContent() {
 
   // APIから時刻表データを取得する関数
   const fetchTimetableData = useCallback(async () => {
-    if (selectedDeparture == null || !selectedDate) return
-
+    if (selectedDepartureGroupId == null || !selectedDate) return
+    setIsLoadingTimetable(true)
     // client.GET の期待する型に合わせて修正
     const paramsForGet: operations['BusStopGroupsService_getBusStopGroupsTimetable']['parameters'] =
       {
         path: {
-          id: selectedDeparture,
+          id: selectedDepartureGroupId,
         },
       }
-
     if (selectedDate) {
       paramsForGet.query = { date: format(selectedDate, 'yyyy-MM-dd') }
     }
-
     // client.GET の呼び出しでは、{ params: ... } の形にする
     const { data, error } = await client.GET('/api/bus-stops/groups/{id}/timetable', {
       params: paramsForGet,
     })
-
+    setIsLoadingTimetable(false)
     if (error) {
       console.error('Failed to fetch timetable data:', error)
       setTimetableData(null)
       return
     }
     setTimetableData(data)
-  }, [selectedDeparture, selectedDate])
+  }, [selectedDepartureGroupId, selectedDate])
 
   // 出発地、日付が変更されたらAPIからデータを再取得
   useEffect(() => {
-    if (selectedDeparture != null && selectedDate) {
+    if (selectedDepartureGroupId != null && selectedDate) {
       fetchTimetableData()
     }
-  }, [selectedDeparture, selectedDate, fetchTimetableData])
+  }, [selectedDepartureGroupId, selectedDate, fetchTimetableData])
 
   // 出発地と目的地を入れ替える
   const swapStations = useCallback(() => {
-    if (!selectedDeparture || !selectedDestination) return
+    if (!selectedDepartureGroupId || !selectedDestinationGroupId) return
     if (
-      selectedDeparture === selectedDestination ||
-      !canSwapStations(selectedDestination, selectedDeparture, timetableData) // timetableData を追加
+      selectedDepartureGroupId === selectedDestinationGroupId ||
+      !canSwapStations(selectedDepartureGroupId, selectedDestinationGroupId)
     )
       return
-    setSelectedDeparture(selectedDestination)
-    setSelectedDestination(selectedDeparture)
-  }, [selectedDeparture, selectedDestination, timetableData])
+    setSelectedDepartureGroupId(selectedDestinationGroupId)
+    setSelectedDestinationGroupId(selectedDepartureGroupId)
+  }, [selectedDepartureGroupId, selectedDestinationGroupId])
+
+  // バス停グループ一覧の状態を追加
+  const [busStopGroups, setBusStopGroups] = useState<components['schemas']['Models.BusStopGroup'][]>([])
+
+  // バス停グループ一覧を取得
+  useEffect(() => {
+    const fetchBusStopGroups = async () => {
+      try {
+        const { data, error } = await client.GET('/api/bus-stops/groups')
+        if (error) {
+          setBusStopGroups([])
+        } else if (data) {
+          setBusStopGroups(data)
+        }
+      } catch {
+        setBusStopGroups([])
+      }
+    }
+    fetchBusStopGroups()
+  }, [])
 
   // フィルタリングされた時刻表データ
   const filteredTimetable = useMemo(() => {
-    if (!timetableData || !selectedDate || !now || selectedDeparture == null) return []
-
-    // selectedDestination が null の場合、filterTimetable には undefined を渡すか、
-    // もしくは filterTimetable 側で null を許容するように修正する必要がある。
-    // ここでは、一旦そのまま null を渡すが、filterTimetable の修正が必要になる可能性を示唆。
+    if (!timetableData || !selectedDate || !now || selectedDepartureGroupId == null) return []
     return filterTimetable(
-      selectedDeparture!,
-      selectedDestination, // null の可能性がある
+      busStopGroups,
+      selectedDepartureGroupId, // グループID
+      selectedDestinationGroupId, // バス停ID（null許容）
       timeFilter,
       startTime,
       endTime,
-      selectedDate,
       now,
-      timetableData // APIから取得した時刻表データ
+      timetableData
     )
   }, [
-    selectedDeparture,
-    selectedDestination, // 依存配列には残す
+    busStopGroups,
+    selectedDepartureGroupId,
+    selectedDestinationGroupId,
     timeFilter,
     startTime,
     endTime,
@@ -221,10 +235,10 @@ function TimetableContent() {
       <div className="grid grid-cols-1 md:grid-cols-[320px_1fr] gap-6">
         <div>
           <TimetableFilter
-            selectedDeparture={selectedDeparture}
-            setSelectedDeparture={setSelectedDeparture}
-            selectedDestination={selectedDestination}
-            setSelectedDestination={setSelectedDestination}
+            selectedDeparture={selectedDepartureGroupId}
+            setSelectedDeparture={setSelectedDepartureGroupId}
+            selectedDestination={selectedDestinationGroupId}
+            setSelectedDestination={setSelectedDestinationGroupId}
             selectedDate={selectedDate}
             setSelectedDate={setSelectedDate}
             now={now}
@@ -235,15 +249,16 @@ function TimetableContent() {
             endTime={endTime}
             setEndTime={setEndTime}
             swapStations={swapStations}
+            busStopGroups={busStopGroups}
           />
         </div>
-
         <TimetableDisplay
-          selectedDeparture={selectedDeparture}
-          selectedDestination={selectedDestination}
+          selectedDeparture={selectedDepartureGroupId}
+          selectedDestination={selectedDestinationGroupId}
           filteredTimetable={filteredTimetable}
           now={now}
           timetableData={timetableData}
+          isLoading={isLoadingTimetable}
         />
       </div>
     </div>

--- a/apps/web/components/timetable/route-info-card.tsx
+++ b/apps/web/components/timetable/route-info-card.tsx
@@ -1,8 +1,9 @@
 import { Badge } from '@/components/ui/badge'
-import { FaShuttleVan } from 'react-icons/fa'
-import { getShuttleSegments } from '@/lib/utils/timetable'
-import { DisplayBusInfo } from '@/lib/types/timetable'
+import { Skeleton } from '@/components/ui/skeleton'
 import type { components } from '@/generated/oas'
+import { DisplayBusInfo } from '@/lib/types/timetable'
+import { getShuttleSegments } from '@/lib/utils/timetable'
+import { FaShuttleVan } from 'react-icons/fa'
 
 interface RouteInfoCardProps {
   timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null
@@ -18,11 +19,28 @@ export function RouteInfoCard({
   timetableData,
   selectedDeparture,
   selectedDestination,
-}: RouteInfoCardProps) {
+  busStopGroups,
+  isLoading = false,
+}: RouteInfoCardProps & { busStopGroups: components['schemas']['Models.BusStopGroup'][]; isLoading?: boolean }) {
+  if (isLoading) {
+    return (
+      <div className="space-y-3 px-2 pt-2">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-20 rounded" />
+          <Skeleton className="h-4 w-16 rounded" />
+        </div>
+        <Skeleton className="h-6 w-full rounded" />
+        <Skeleton className="h-4 w-2/3 rounded" />
+      </div>
+    )
+  }
+  const shuttleSegments = (selectedDeparture != null && selectedDestination != null)
+    ? getShuttleSegments(busStopGroups, timetableData, selectedDeparture, selectedDestination)
+    : []
+
   if (selectedDeparture == null || selectedDestination == null) return null
 
   // フィルタリングされた運行情報から各セグメントを抽出
-  const shuttleSegments = getShuttleSegments(timetableData, selectedDeparture, selectedDestination)
 
   return (
     <div className="space-y-3">

--- a/apps/web/components/timetable/timetable-display.tsx
+++ b/apps/web/components/timetable/timetable-display.tsx
@@ -1,12 +1,13 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { FaClock, FaMapMarkerAlt, FaArrowRight } from 'react-icons/fa'
 import type { components } from '@/generated/oas'
 import { DisplayBusInfo } from '@/lib/types/timetable'
+import { getBusStatus } from '@/lib/utils/timetable'
+import { FaArrowRight, FaClock, FaMapMarkerAlt } from 'react-icons/fa'
 import { BusRow } from './bus-row'
 import { RouteInfoCard } from './route-info-card'
-import { getBusStatus } from '@/lib/utils/timetable'
 
 export interface TimetableDisplayProps {
   selectedDeparture: number | null
@@ -14,6 +15,7 @@ export interface TimetableDisplayProps {
   filteredTimetable: DisplayBusInfo[]
   now: Date | null
   timetableData?: components['schemas']['Models.BusStopGroupTimetable'] | null
+  isLoading?: boolean // 追加
 }
 
 /**
@@ -26,6 +28,7 @@ export function TimetableDisplay({
   filteredTimetable,
   now,
   timetableData,
+  isLoading = false, // デフォルトfalse
 }: TimetableDisplayProps) {
   return (
     <Card className="shadow-sm overflow-hidden pt-0 gap-2">
@@ -83,6 +86,29 @@ export function TimetableDisplay({
               出発地を選択すると、利用可能な時刻表が表示されます。
             </p>
           </div>
+        ) : isLoading ? (
+          <div className="py-10 px-5">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="text-xs font-medium pl-4 md:pl-6">目的地</TableHead>
+                  <TableHead className="text-xs font-medium">出発時刻</TableHead>
+                  <TableHead className="text-xs font-medium hidden md:table-cell">到着時刻</TableHead>
+                  <TableHead className="text-right text-xs font-medium"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {[...Array(5)].map((_, i) => (
+                  <TableRow key={i}>
+                    <td className="pl-4 md:pl-6 py-2"><Skeleton className="h-6 w-24 rounded" /></td>
+                    <td className="py-2"><Skeleton className="h-6 w-20 rounded" /></td>
+                    <td className="py-2 hidden md:table-cell"><Skeleton className="h-6 w-20 rounded" /></td>
+                    <td className="py-2 text-right"><Skeleton className="h-6 w-8 rounded ml-auto" /></td>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         ) : filteredTimetable.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16 px-5 text-center">
             <div className="rounded-full bg-muted p-4 mb-4">
@@ -102,6 +128,8 @@ export function TimetableDisplay({
                   timetableData={timetableData}
                   selectedDeparture={selectedDeparture}
                   selectedDestination={selectedDestination}
+                  busStopGroups={[]}
+                  isLoading={isLoading}
                 />
               </div>
             )}

--- a/apps/web/components/timetable/timetable-filter.tsx
+++ b/apps/web/components/timetable/timetable-filter.tsx
@@ -1,15 +1,6 @@
-import { useMemo, useState, useEffect } from 'react' // useEffect を追加
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { Calendar } from '@/components/ui/calendar'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Dialog,
   DialogContent,
@@ -17,14 +8,22 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { Calendar } from '@/components/ui/calendar'
-import { format, addDays } from 'date-fns'
-import { ja } from 'date-fns/locale'
-import { cn } from '@/lib/utils'
-import { FaCalendarAlt, FaClock, FaExchangeAlt, FaMapMarkerAlt } from 'react-icons/fa'
-import { TimeFilterType } from '@/lib/types/timetable'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { components } from '@/generated/oas'
-import { client } from '@/lib/client'
+import { TimeFilterType } from '@/lib/types/timetable'
+import { cn } from '@/lib/utils'
+import { addDays, format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+import { useMemo, useState } from 'react'
+import { FaCalendarAlt, FaClock, FaExchangeAlt, FaMapMarkerAlt } from 'react-icons/fa'
 
 interface TimetableFilterProps {
   selectedDeparture: number | null
@@ -41,6 +40,7 @@ interface TimetableFilterProps {
   endTime: string
   setEndTime: (value: string) => void
   swapStations: () => void
+  busStopGroups: components['schemas']['Models.BusStopGroup'][] // 追加
 }
 
 /**
@@ -62,38 +62,8 @@ export function TimetableFilter({
   endTime,
   setEndTime,
   swapStations,
+  busStopGroups, // 追加
 }: TimetableFilterProps) {
-  const [busStopGroups, setBusStopGroups] = useState<
-    components['schemas']['Models.BusStopGroup'][]
-  >([])
-  const [loadingDepartures, setLoadingDepartures] = useState<boolean>(true)
-
-  useEffect(() => {
-    const fetchBusStopGroups = async () => {
-      setLoadingDepartures(true)
-      try {
-        const { data, error } = await client.GET('/api/bus-stops/groups')
-
-        if (error) {
-          console.error('Error fetching bus stop groups:', error)
-          setBusStopGroups([])
-        } else if (data) {
-          // data.groups を data に変更
-          setBusStopGroups(data) // data.groups を data に変更
-        } else {
-          setBusStopGroups([])
-        }
-      } catch (err) {
-        console.error('Exception fetching bus stop groups:', err)
-        setBusStopGroups([])
-      } finally {
-        setLoadingDepartures(false)
-      }
-    }
-
-    fetchBusStopGroups()
-  }, [])
-
   // 日付タブの設定
   const dateTabs = useMemo(
     () => [
@@ -104,22 +74,9 @@ export function TimetableFilter({
     [now]
   )
 
-  // 出発地リスト: APIデータがあればそれを使う
-  const availableDepartures = useMemo(() => {
-    return busStopGroups.map((group) => ({ id: group.id, name: group.name }))
-  }, [busStopGroups])
-
-  // 目的地リスト: APIデータがあればそれを使う
-  const availableDestinations = useMemo(() => {
-    // APIから取得したバス停グループを目的地の候補として使用
-    // 選択された出発地と同じものは除外する
-    return busStopGroups
-      .map((group) => ({ id: group.id, name: group.name }))
-      .filter((group) => selectedDeparture === null || group.id !== selectedDeparture)
-  }, [busStopGroups, selectedDeparture])
-
   // カレンダーのオープン状態
   const [calendarOpen, setCalendarOpen] = useState<boolean>(false)
+  const isLoadingBusStopGroups = busStopGroups.length === 0
 
   return (
     <Card className="shadow-sm overflow-hidden pt-0 gap-2">
@@ -269,39 +226,32 @@ export function TimetableFilter({
             </div>
             <Select
               value={selectedDeparture !== null ? String(selectedDeparture) : ''}
-              onValueChange={(value) => {
+              onValueChange={(value: string) => {
                 setSelectedDeparture(value === '' ? null : Number(value))
               }}
+              disabled={isLoadingBusStopGroups}
             >
               <SelectTrigger
                 className={cn(
                   'rounded-md h-10 w-full cursor-pointer',
                   !selectedDeparture ? 'text-muted-foreground' : ''
                 )}
+                disabled={isLoadingBusStopGroups}
               >
-                <SelectValue
-                  placeholder={
-                    loadingDepartures
-                      ? '出発地を読み込み中...'
-                      : availableDepartures.length === 0
-                        ? '利用可能な出発地がありません'
-                        : '出発地を選択'
-                  }
-                />
+                <div className="flex items-center w-full">
+                  <SelectValue
+                    placeholder={isLoadingBusStopGroups ? '読み込み中...' : '出発地を選択'}
+                    className="flex-1 text-left"
+                  />
+                </div>
               </SelectTrigger>
               <SelectContent>
-                {loadingDepartures ? (
-                  <div className="py-2 px-2 text-xs text-muted-foreground text-center">
-                    読み込み中...
-                  </div>
-                ) : availableDepartures.length === 0 ? (
-                  <div className="py-2 px-2 text-xs text-muted-foreground text-center">
-                    利用可能な出発地がありません
-                  </div>
+                {isLoadingBusStopGroups ? (
+                  <SelectItem value="_loading" disabled>読み込み中...</SelectItem>
                 ) : (
-                  availableDepartures.map((stop) => (
-                    <SelectItem key={stop.id} value={String(stop.id)} className="cursor-pointer">
-                      {stop.name}
+                  busStopGroups.map((group) => (
+                    <SelectItem key={group.id} value={String(group.id)}>
+                      {group.name}
                     </SelectItem>
                   ))
                 )}
@@ -328,64 +278,40 @@ export function TimetableFilter({
             </div>{' '}
             <Select
               value={selectedDestination !== null ? String(selectedDestination) : ''}
-              onValueChange={(value) => {
+              onValueChange={(value: string) => {
                 if (value === '__UNSELECTED_DESTINATION__') {
                   setSelectedDestination(null)
                 } else {
-                  setSelectedDestination(value === '' ? null : Number(value)) // Keep original logic for empty string just in case, though Number('') is 0
+                  setSelectedDestination(Number(value))
                 }
               }}
+              disabled={isLoadingBusStopGroups}
             >
               <SelectTrigger
                 className={cn(
                   'rounded-md h-10 w-full cursor-pointer',
                   !selectedDestination ? 'text-muted-foreground' : ''
                 )}
+                disabled={isLoadingBusStopGroups}
               >
-                <SelectValue
-                  placeholder={
-                    loadingDepartures // 読み込み状態を最初にチェック
-                      ? '停留所を読み込み中...'
-                      : !selectedDeparture
-                        ? '先に出発地を選択してください'
-                        : availableDestinations.length === 0
-                          ? selectedDeparture !== null
-                            ? '選択した出発地からの目的地がありません'
-                            : '利用可能な目的地がありません'
-                          : '目的地を選択'
-                  }
-                />
+                <div className="flex items-center w-full">
+                  <SelectValue
+                    placeholder={isLoadingBusStopGroups ? '読み込み中...' : (!selectedDeparture ? '先に出発地を選択してください' : '目的地を選択')}
+                    className="flex-1 text-left"
+                  />
+                </div>
               </SelectTrigger>
               <SelectContent>
-                {loadingDepartures ? (
-                  <div className="py-2 px-2 text-xs text-muted-foreground text-center">
-                    読み込み中...
-                  </div>
-                ) : !selectedDeparture ? (
-                  <div className="py-2 px-2 text-xs text-muted-foreground text-center">
-                    先に出発地を選択してください
-                  </div>
-                ) : availableDestinations.length === 0 ? (
-                  <div className="py-2 px-2 text-xs text-muted-foreground text-center">
-                    {selectedDeparture !== null
-                      ? '選択した出発地からの有効な目的地がありません'
-                      : '利用可能な目的地がありません'}
-                  </div>
+                {isLoadingBusStopGroups ? (
+                  <SelectItem value="_loading" disabled>読み込み中...</SelectItem>
                 ) : (
-                  <div>
-                    <SelectItem
-                      key="__unselected__"
-                      value="__UNSELECTED_DESTINATION__"
-                      className="cursor-pointer"
-                    >
-                      未選択
-                    </SelectItem>
-                    {availableDestinations.map((stop) => (
-                      <SelectItem key={stop.id} value={String(stop.id)} className="cursor-pointer">
-                        {stop.name}
+                  busStopGroups
+                    .filter((group) => selectedDeparture === null || group.id !== selectedDeparture)
+                    .map((group) => (
+                      <SelectItem key={group.id} value={String(group.id)}>
+                        {group.name}
                       </SelectItem>
-                    ))}
-                  </div>
+                    ))
                 )}
               </SelectContent>
             </Select>

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/apps/web/lib/utils/timetable.ts
+++ b/apps/web/lib/utils/timetable.ts
@@ -1,26 +1,27 @@
+import type { components } from '@/generated/oas'
 import { format } from 'date-fns'
 import { BusStatus, DisplayBusInfo, StopInfo, TimeFilterType } from '../types/timetable'
-import type { components } from '@/generated/oas'
 
 /**
  * 時刻表データから表示用バスデータを生成します
  */
 export const generateDisplayBuses = (
+  busStopGroups: components['schemas']['Models.BusStopGroup'][],
   timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null,
-  selectedDepartureGroupId: number,
-  selectedDestinationStopId: number | null // nullを許容するように変更
+  selectedDestinationGroupId: number | null // 目的地グループID（null許容）
 ): DisplayBusInfo[] => {
   const displayBuses: DisplayBusInfo[] = []
   if (!timetableData || !timetableData.segments) return displayBuses
 
   // APIのデータ構造に合わせて変換
   for (const segment of timetableData.segments) {
-    // 目的地フィルタリング（null または空文字列の場合はすべての目的地を表示）
+    // destination.stopIdからグループIDを特定
+    const stopIdNum = Number(segment.destination.stopId)
+    const group = busStopGroups.find(g => g.busStops.some(s => s.id === stopIdNum))
+    const destinationGroupId = group ? group.id : stopIdNum // fallback: stopId自身
     if (
-      selectedDestinationStopId !== null && // nullでない場合のみフィルタリング
-      segment.destination.stopId !== undefined &&
-      segment.destination.stopId !== null &&
-      segment.destination.stopId !== selectedDestinationStopId
+      selectedDestinationGroupId !== null &&
+      destinationGroupId !== selectedDestinationGroupId
     ) {
       continue
     }
@@ -28,11 +29,13 @@ export const generateDisplayBuses = (
     const departureInfo = {
       stopId: timetableData.id.toString(),
       stopName: timetableData.name,
+      groupId: timetableData.id,
     }
 
     const destinationInfo = {
       stopId: segment.destination.stopId.toString(),
       stopName: segment.destination.stopName,
+      groupId: destinationGroupId,
     }
 
     if (segment.segmentType === 'fixed' && segment.times && segment.times.length > 0) {
@@ -44,8 +47,8 @@ export const generateDisplayBuses = (
           destination: destinationInfo,
           date: timetableData.date,
           segmentType: 'fixed',
-          isFirstBus: false, // 後でソート後に設定するため初期値はfalse
-          isLastBus: false, // 後でソート後に設定するため初期値はfalse
+          isFirstBus: false,
+          isLastBus: false,
         })
       })
     } else if (
@@ -55,14 +58,14 @@ export const generateDisplayBuses = (
       segment.intervalRange
     ) {
       displayBuses.push({
-        departureTime: segment.startTime, // シャトル便の開始時刻を出発時刻とする
-        arrivalTime: segment.endTime, // シャトル便の終了時刻を到着時刻とする（仮）
+        departureTime: segment.startTime,
+        arrivalTime: segment.endTime,
         departure: departureInfo,
         destination: destinationInfo,
         date: timetableData.date,
         segmentType: 'shuttle',
-        isFirstBus: false, // 後でソート後に設定するため初期値はfalse
-        isLastBus: false, // 後でソート後に設定するため初期値はfalse
+        isFirstBus: false,
+        isLastBus: false,
         shuttleTimeRange: {
           startTime: segment.startTime,
           endTime: segment.endTime,
@@ -75,12 +78,11 @@ export const generateDisplayBuses = (
     }
   }
 
-  // displayBuses.sort((a, b) => a.departureTime.localeCompare(b.departureTime)) // 元のコード
   displayBuses.sort((a, b) => toMinutes(a.departureTime) - toMinutes(b.departureTime))
 
   // ソート後に目的地ごとにグループ化して、その日全体での最初と最後のバスを特定する
   if (displayBuses.length > 0) {
-    // 目的地IDごとにバスをグループ化
+    // 目的地グループIDごとにバスをグループ化
     const busesByDestination: { [key: string]: DisplayBusInfo[] } = {}
 
     displayBuses.forEach((bus) => {
@@ -94,7 +96,6 @@ export const generateDisplayBuses = (
     // 各目的地グループ内で、最初と最後のバスを設定
     Object.values(busesByDestination).forEach((destinationBuses) => {
       if (destinationBuses.length > 0) {
-        // 各目的地ごとの最初と最後を設定
         destinationBuses.sort((a, b) => toMinutes(a.departureTime) - toMinutes(b.departureTime))
         destinationBuses.forEach((bus) => {
           bus.isFirstBus = false
@@ -113,109 +114,118 @@ export const generateDisplayBuses = (
  * 日付と出発地、目的地などの条件に基づいてバスの時刻表をフィルタリングします
  */
 export const filterTimetable = (
-  selectedDepartureGroupId: number,
-  selectedDestinationStopId: number | null, // nullを許容するように変更
+  busStopGroups: components['schemas']['Models.BusStopGroup'][],
+  selectedDepartureGroupId: number, // 出発地グループID
+  selectedDestinationGroupId: number | null, // 目的地グループID（null許容）
   timeFilter: TimeFilterType,
   startTime: string,
   endTime: string,
-  selectedDate: Date | null,
   now: Date | null,
-  timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null // APIからのデータを追加
+  timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null
 ): DisplayBusInfo[] => {
   let displayBuses = generateDisplayBuses(
+    busStopGroups,
     timetableData,
-    selectedDepartureGroupId,
-    selectedDestinationStopId
+    selectedDestinationGroupId
   )
 
-  // フィルタリングの前に、まずソートを行う (generateDisplayBusesでソート済みのため、本来は不要だが念のため修正)
-  // displayBuses.sort((a, b) => a.departureTime.localeCompare(b.departureTime)) // 元のコード
+  displayBuses = displayBuses.filter(
+    (bus) => Number(bus.departure.stopId) === selectedDepartureGroupId
+  )
+
   displayBuses.sort((a, b) => toMinutes(a.departureTime) - toMinutes(b.departureTime))
 
   if (timeFilter === 'all') {
     // 'all' の場合は既にソート済みなので何もしない
   } else if (timeFilter === 'preDeparture') {
     displayBuses = applyPreDepartureFilter(displayBuses, now)
-    // applyPreDepartureFilter の中でソートされる
   } else if (timeFilter === 'departure') {
     displayBuses = applyDepartureTimeFilter(displayBuses, startTime)
-    // applyDepartureTimeFilter の中でソートされる
   } else if (timeFilter === 'arrival') {
     displayBuses = applyArrivalTimeFilter(displayBuses, endTime)
-    // 到着時間でフィルタリングした場合、到着時間で逆順にソートする（遅い順に表示）
     displayBuses.sort((a, b) => {
-      const arrivalA = a.arrivalTime || a.departureTime // フォールバック
-      const arrivalB = b.arrivalTime || b.departureTime // フォールバック
-      // 到着時間の降順でソート（遅い → 早い順）
+      const arrivalA = a.arrivalTime || a.departureTime
+      const arrivalB = b.arrivalTime || b.departureTime
       return toMinutes(arrivalB) - toMinutes(arrivalA)
     })
   }
-
-  // フィルタリング後も、元の isFirstBus と isLastBus の設定を維持する
-  // フィルタリングでは isFirstBus と isLastBus の状態を変更しない
 
   return displayBuses
 }
 
 /**
- * 出発前のバスのみフィルタリングする
+ * 出発地に基づいて利用可能な目的地のリストを返します
  */
-const applyPreDepartureFilter = (buses: DisplayBusInfo[], now: Date | null): DisplayBusInfo[] => {
-  if (!now) return buses
-
-  // 現在時刻以降のバスをフィルタリング
-  const nowTimeStr = format(now, 'HH:mm')
-
-  const filtered = buses.filter((bus) => {
-    if (bus.segmentType === 'shuttle' && bus.shuttleTimeRange) {
-      // シャトル便の場合、運行終了時刻が現在時刻以降であれば表示
-      return isTimeAfterOrEqual(bus.shuttleTimeRange.endTime, nowTimeStr)
-    }
-    // 通常便の場合は出発時間で判断
-    return isTimeAfterOrEqual(bus.departureTime, nowTimeStr)
-  })
-  // フィルタリング後もソート順を維持、または再ソート
-  // return filtered.sort((a,b) => a.departureTime.localeCompare(b.departureTime)); // 元のコード
-  return filtered.sort((a, b) => toMinutes(a.departureTime) - toMinutes(b.departureTime))
+export const getAvailableDestinations = (
+  selectedDepartureGroupId: number, // グループID
+  timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null
+): StopInfo[] => {
+  if (!timetableData || !timetableData.segments) return []
+  // 出発地グループIDと同じグループの目的地は除外
+  return timetableData.segments
+    .filter((segment) => Number(segment.destination.stopId) !== selectedDepartureGroupId)
+    .map((segment) => ({
+      id: Number(segment.destination.stopId),
+      name: segment.destination.stopName,
+    }))
 }
 
-/**
- * 指定出発時間以降のバスをフィルタリングする
- */
-const applyDepartureTimeFilter = (buses: DisplayBusInfo[], startTime: string): DisplayBusInfo[] => {
-  const filtered = buses.filter((bus) => {
-    if (bus.segmentType === 'shuttle' && bus.shuttleTimeRange) {
-      // シャトル便の場合、指定された開始時間が運行時間内に含まれているか、
-      // または運行開始時間が指定時間以降なら表示
-      return (
-        (isTimeBeforeOrEqual(bus.shuttleTimeRange.startTime, startTime) &&
-          isTimeAfterOrEqual(bus.shuttleTimeRange.endTime, startTime)) ||
-        isTimeAfterOrEqual(bus.shuttleTimeRange.startTime, startTime)
-      )
-    }
-    return isTimeAfterOrEqual(bus.departureTime, startTime)
-  })
-  // フィルタリング後もソート順を維持、または再ソート
-  // return filtered.sort((a,b) => a.departureTime.localeCompare(b.departureTime)); // 元のコード
-  return filtered.sort((a, b) => toMinutes(a.departureTime) - toMinutes(b.departureTime))
+export const getAvailableDepartures = (
+  selectedDestinationGroupId: number, // グループID
+  timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null
+): StopInfo[] => {
+  if (!timetableData) return []
+  const departures: StopInfo[] = [
+    {
+      id: timetableData.id,
+      name: timetableData.name,
+    },
+  ]
+  if (!selectedDestinationGroupId) return departures
+  return departures.filter((dep) => dep.id !== selectedDestinationGroupId)
 }
 
-/**
- * 指定到着時間以前のバスをフィルタリングする
- */
-const applyArrivalTimeFilter = (buses: DisplayBusInfo[], endTime: string): DisplayBusInfo[] => {
-  const filtered = buses.filter((bus) => {
-    // シャトル便の場合、arrivalTime が存在しない可能性があるため、shuttleTimeRange.endTime を使用
-    const arrivalTimeToCompare =
-      bus.segmentType === 'shuttle' && bus.shuttleTimeRange
-        ? bus.shuttleTimeRange.endTime
-        : bus.arrivalTime
-    if (!arrivalTimeToCompare) return false // 到着時刻がない場合はフィルタリング対象外
-    return isTimeBeforeOrEqual(arrivalTimeToCompare, endTime)
-  })
+export const canSwapStations = (
+  selectedDepartureGroupId: number, // グループID
+  selectedDestinationGroupId: number // グループID
+): boolean => {
+  return !!selectedDepartureGroupId && !!selectedDestinationGroupId
+}
 
-  // filterTimetable関数内でソートするため、ここではソートせずにフィルタリングしたリストをそのまま返す
-  return filtered
+export const getShuttleSegments = (
+  busStopGroups: components['schemas']['Models.BusStopGroup'][],
+  timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null,
+  selectedDepartureGroupId: number,
+  selectedDestinationGroupId: number
+): DisplayBusInfo[] => {
+  return generateDisplayBuses(busStopGroups, timetableData, selectedDestinationGroupId).filter(
+    (bus) =>
+      bus.segmentType === 'shuttle' &&
+      Number(bus.departure.stopId) === selectedDepartureGroupId &&
+      Number(bus.destination.stopId) === selectedDestinationGroupId
+  )
+}
+
+// "HH:mm" 形式の時刻文字列を分単位の数値に変換する関数
+const toMinutes = (timeStr: string): number => {
+  if (!timeStr || !timeStr.includes(':')) {
+    // timeStr が null や undefined、または予期せぬ形式の場合のフォールバック
+    return 0 // またはエラーをスローするか、適切なデフォルト値を返す
+  }
+  const [hours, minutes] = timeStr.split(':').map(Number)
+  return hours * 60 + minutes
+}
+
+const isTimeAfterOrEqual = (time1: string, time2: string): boolean => {
+  return toMinutes(time1) >= toMinutes(time2)
+}
+
+const isTimeBeforeOrEqual = (time1: string, time2: string): boolean => {
+  return toMinutes(time1) <= toMinutes(time2)
+}
+
+const getTimeDifferenceInMinutes = (time1: string, time2: string): number => {
+  return Math.abs(toMinutes(time1) - toMinutes(time2))
 }
 
 /**
@@ -363,105 +373,41 @@ const handleDepartedBusStatus = (
   }
 }
 
-/**
- * 出発地に基づいて利用可能な目的地のリストを返します
- */
-export const getAvailableDestinations = (
-  selectedDeparture: number,
-  timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null
-): StopInfo[] => {
-  if (!timetableData || !timetableData.segments) return []
-  // 出発地を除外した目的地のリストを返す
-  if (!selectedDeparture) {
-    return timetableData.segments.map((segment) => ({
-      id: segment.destination.stopId,
-      name: segment.destination.stopName,
-      // available: true, // StopInfoに存在しないためコメントアウト
-    }))
-  }
-  // 出発地として選択された停留所を除外
-  return timetableData.segments
-    .filter((segment) => segment.destination.stopId !== selectedDeparture)
-    .map((segment) => ({
-      id: segment.destination.stopId,
-      name: segment.destination.stopName,
-      // available: true, // StopInfoに存在しないためコメントアウト
-    }))
+// --- フィルター関数（グループIDベースでそのまま利用） ---
+const applyPreDepartureFilter = (buses: DisplayBusInfo[], now: Date | null): DisplayBusInfo[] => {
+  if (!now) return buses
+  const nowTimeStr = format(now, 'HH:mm')
+  const filtered = buses.filter((bus) => {
+    if (bus.segmentType === 'shuttle' && bus.shuttleTimeRange) {
+      return isTimeAfterOrEqual(bus.shuttleTimeRange.endTime, nowTimeStr)
+    }
+    return isTimeAfterOrEqual(bus.departureTime, nowTimeStr)
+  })
+  return filtered.sort((a, b) => toMinutes(a.departureTime) - toMinutes(b.departureTime))
 }
 
-/**
- * 目的地に基づいて利用可能な出発地のリストを返します
- */
-export const getAvailableDepartures = (
-  selectedDestination: number,
-  timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null
-): StopInfo[] => {
-  if (!timetableData) return []
-  // 目的地が選択されていない場合はすべての出発地を返す
-  // 目的地と同じ出発地は選べないようにする
-  const departures: StopInfo[] = [
-    {
-      id: timetableData.id,
-      name: timetableData.name,
-      // available: true, // StopInfoに存在しないためコメントアウト
-    },
-  ]
-  if (!selectedDestination) return departures
-  return departures.filter((dep) => dep.id !== selectedDestination)
+const applyDepartureTimeFilter = (buses: DisplayBusInfo[], startTime: string): DisplayBusInfo[] => {
+  const filtered = buses.filter((bus) => {
+    if (bus.segmentType === 'shuttle' && bus.shuttleTimeRange) {
+      return (
+        (isTimeBeforeOrEqual(bus.shuttleTimeRange.startTime, startTime) &&
+          isTimeAfterOrEqual(bus.shuttleTimeRange.endTime, startTime)) ||
+        isTimeAfterOrEqual(bus.shuttleTimeRange.startTime, startTime)
+      )
+    }
+    return isTimeAfterOrEqual(bus.departureTime, startTime)
+  })
+  return filtered.sort((a, b) => toMinutes(a.departureTime) - toMinutes(b.departureTime))
 }
 
-/**
- * 出発地と目的地を入れ替えるが、可能な場合にのみ入れ替える
- */
-export const canSwapStations = (
-  selectedDeparture: number,
-  selectedDestination: number,
-  timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null
-): boolean => {
-  if (!selectedDeparture || !selectedDestination || !timetableData || !timetableData.segments)
-    return false
-
-  const departureExistsAsDestination = timetableData.segments.some(
-    (segment) => segment.destination.stopId === selectedDeparture
-  )
-  // timetableData.id が selectedDestination と一致するかどうかで判定
-  const destinationExistsAsDeparture = timetableData.id === selectedDestination
-
-  return departureExistsAsDestination && destinationExistsAsDeparture
-}
-
-/**
- * シャトル便のセグメントを取得
- * timetableData, selectedDeparture, selectedDestination を元にシャトル便のみ抽出
- */
-export const getShuttleSegments = (
-  timetableData: components['schemas']['Models.BusStopGroupTimetable'] | null,
-  selectedDeparture: number,
-  selectedDestination: number
-): DisplayBusInfo[] => {
-  return generateDisplayBuses(timetableData, selectedDeparture, selectedDestination).filter(
-    (bus) => bus.segmentType === 'shuttle'
-  )
-}
-
-// "HH:mm" 形式の時刻文字列を分単位の数値に変換する関数
-const toMinutes = (timeStr: string): number => {
-  if (!timeStr || !timeStr.includes(':')) {
-    // timeStr が null や undefined、または予期せぬ形式の場合のフォールバック
-    return 0 // またはエラーをスローするか、適切なデフォルト値を返す
-  }
-  const [hours, minutes] = timeStr.split(':').map(Number)
-  return hours * 60 + minutes
-}
-
-const isTimeAfterOrEqual = (time1: string, time2: string): boolean => {
-  return toMinutes(time1) >= toMinutes(time2)
-}
-
-const isTimeBeforeOrEqual = (time1: string, time2: string): boolean => {
-  return toMinutes(time1) <= toMinutes(time2)
-}
-
-const getTimeDifferenceInMinutes = (time1: string, time2: string): number => {
-  return Math.abs(toMinutes(time1) - toMinutes(time2))
+const applyArrivalTimeFilter = (buses: DisplayBusInfo[], endTime: string): DisplayBusInfo[] => {
+  const filtered = buses.filter((bus) => {
+    const arrivalTimeToCompare =
+      bus.segmentType === 'shuttle' && bus.shuttleTimeRange
+        ? bus.shuttleTimeRange.endTime
+        : bus.arrivalTime
+    if (!arrivalTimeToCompare) return false
+    return isTimeBeforeOrEqual(arrivalTimeToCompare, endTime)
+  })
+  return filtered
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "fix": "run-s fix:prettier fix:eslint",
     "fix:eslint": "pnpm lint:eslint --fix --quiet",
     "fix:prettier": "pnpm lint:prettier --write",
-    "dev": "next dev --turbo",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
- 時刻表ページをリファクタリングし、表示用バス情報の生成にバス停グループを利用するようにしました。
- 時刻表表示コンポーネントとルート情報カードコンポーネントの読み込み状態を改善しました。
- フィルタリングロジックをバス停IDではなくグループIDに対応させました。
- データ取得中のユーザー体験を向上させるため、スケルトンローディングを導入しました。
- バス停グループ取得のAPI呼び出しを簡素化し、エラー処理を強化しました。
- 出発地に応じた利用可能な目的地をタイムテーブルフィルタで反映するよう調整しました。
- フィルターコンポーネントから不要なバス停グループのステート管理を削除しました。
- 可読性と保守性を高めるため、ユーティリティ関数を整理しました。