### PR TITLE
Update API environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ TypeScript, Go, Typespec
 #### ハッカソンで開発した独自機能・技術
 
 - ホーム画面のUI
+
+### Development
+
+The API reads the `ENVIRONMENT` variable to switch between development and
+production modes. `docker-compose.yml` sets `ENVIRONMENT=development` for local
+use. `API_ENV` is still accepted for backward compatibility.

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -52,7 +52,9 @@ func LoadConfig() (*Config, error) {
 		log.Println("✅ .env file loaded successfully")
 	}
 
-	env := getEnv("API_ENV", "prod")
+	// ENVIRONMENT is used in docker-compose for the API container.
+	// Fallback to API_ENV for backward compatibility.
+	env := getEnv("ENVIRONMENT", getEnv("API_ENV", "prod"))
 	allowedOrigins := []string{}
 	if env == "dev" || env == "development" {
 		allowedOrigins = []string{


### PR DESCRIPTION
## Summary
- support `ENVIRONMENT` environment variable in API config
- document `ENVIRONMENT` usage in README

## Testing
- `go build ./...`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854e68d42588323824ddc1a1543c312