### PR TITLE
Fix gen clients script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gen:spec": "pnpm --filter spec run gen:spec",
     "gen:ts": "pnpm --filter spec run gen:ts",
     "gen:go": "pnpm --filter spec run gen:go",
-    "gen:clients": "pnpm run gen:spec:ts && pnpm run gen:spec:go",
+    "gen:clients": "pnpm run gen:ts && pnpm run gen:go",
     "dev:web": "pnpm --filter web run dev",
     "build:web": "pnpm --filter web run build",
     "start:web": "pnpm --filter web run start",


### PR DESCRIPTION
## Summary
- update `gen:clients` script to run typescript and go generation

## Testing
- `pnpm install`
- `pnpm run gen:clients` *(fails: openapi.yaml missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854e68aa83483239369d58930f67e43