### PR TITLE
dev → main: Terraform ワークフロー修正 & Vercel 設定改善

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -58,6 +58,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: '~> 1.14.2'
+          terraform_wrapper: false
 
       - name: Google Cloud Auth
         uses: google-github-actions/auth@v3
@@ -70,14 +71,15 @@ jobs:
 
       - name: Terraform Plan (pre-apply check)
         id: plan
-        run: terraform plan -var-file=environments/production.tfvars -no-color -input=false -detailed-exitcode
-        continue-on-error: true
+        run: |
+          set +e
+          terraform plan -var-file=environments/production.tfvars -no-color -input=false -detailed-exitcode
+          echo "exitcode=$?" >> "$GITHUB_OUTPUT"
 
       - name: Skip if No Changes
         if: steps.plan.outputs.exitcode == '0'
         run: |
           echo "::notice::No changes detected. Skipping apply."
-          exit 0
 
       - name: Fail on Plan Error
         if: steps.plan.outputs.exitcode == '1'

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -37,6 +37,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: '~> 1.14.2'
+          terraform_wrapper: false
 
       - name: Terraform Format Check
         id: fmt
@@ -55,7 +56,16 @@ jobs:
 
       - name: Terraform Validate
         id: validate
-        run: terraform validate -no-color
+        run: |
+          VALIDATE_OUTPUT=$(terraform validate -no-color 2>&1)
+          VALIDATE_EXITCODE=$?
+          echo "$VALIDATE_OUTPUT"
+          {
+            echo "stdout<<__TF_VALIDATE_EOF__"
+            echo "$VALIDATE_OUTPUT"
+            echo "__TF_VALIDATE_EOF__"
+          } >> "$GITHUB_OUTPUT"
+          exit $VALIDATE_EXITCODE
 
       - name: Post PR Comment
         uses: actions/github-script@v8

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -40,6 +40,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: '~> 1.14.2'
+          terraform_wrapper: false
 
       - name: Google Cloud Auth
         uses: google-github-actions/auth@v3
@@ -52,22 +53,31 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -var-file=environments/production.tfvars -no-color -input=false -detailed-exitcode
-        continue-on-error: true
+        run: |
+          set +e
+          PLAN_OUTPUT=$(terraform plan -var-file=environments/production.tfvars -no-color -input=false -detailed-exitcode 2>&1)
+          PLAN_EXITCODE=$?
+          echo "$PLAN_OUTPUT"
+          echo "exitcode=$PLAN_EXITCODE" >> "$GITHUB_OUTPUT"
+          {
+            echo "stdout<<__TF_PLAN_EOF__"
+            echo "$PLAN_OUTPUT"
+            echo "__TF_PLAN_EOF__"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Determine Plan Status
         id: plan_status
         run: |
           EXIT_CODE="${{ steps.plan.outputs.exitcode }}"
           if [ "$EXIT_CODE" = "0" ]; then
-            echo "status=No changes" >> $GITHUB_OUTPUT
-            echo "emoji=✅" >> $GITHUB_OUTPUT
+            echo "status=No changes" >> "$GITHUB_OUTPUT"
+            echo "emoji=✅" >> "$GITHUB_OUTPUT"
           elif [ "$EXIT_CODE" = "2" ]; then
-            echo "status=Changes detected" >> $GITHUB_OUTPUT
-            echo "emoji=⚠️" >> $GITHUB_OUTPUT
+            echo "status=Changes detected" >> "$GITHUB_OUTPUT"
+            echo "emoji=⚠️" >> "$GITHUB_OUTPUT"
           else
-            echo "status=Error" >> $GITHUB_OUTPUT
-            echo "emoji=❌" >> $GITHUB_OUTPUT
+            echo "status=Error" >> "$GITHUB_OUTPUT"
+            echo "emoji=❌" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Post Plan to PR

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -74,6 +74,9 @@ module "vercel" {
   # Deployment Retention
   enable_deployment_retention = var.vercel_enable_deployment_retention
 
+  # Skew Protection
+  skew_protection = var.vercel_skew_protection
+
   # Announcement Banner
   announcement_message   = var.vercel_announcement_message
   announcement_title     = var.vercel_announcement_title

--- a/infra/modules/vercel/main.tf
+++ b/infra/modules/vercel/main.tf
@@ -19,6 +19,13 @@ resource "vercel_project" "main" {
 
   # Production デプロイ時にカスタムドメインを自動割り当て
   auto_assign_custom_domains = true
+
+  # Production ビルドを Preview より優先
+  prioritise_production_builds = true
+
+  # Skew Protection（有効にすると Production デプロイが Staged になり Promote が必要）
+  # 不要な場合は null（未設定）にする
+  skew_protection = var.skew_protection
 }
 
 # 環境変数 - Production
@@ -133,6 +140,7 @@ resource "vercel_project_environment_variable" "better_auth_secret" {
   target     = ["production", "preview"]
   key        = "BETTER_AUTH_SECRET"
   value      = var.better_auth_secret
+  sensitive  = true
 }
 
 # GitHub OAuth - Client ID
@@ -149,6 +157,7 @@ resource "vercel_project_environment_variable" "auth_github_secret" {
   target     = ["production", "preview"]
   key        = "AUTH_GITHUB_SECRET"
   value      = var.auth_github_secret
+  sensitive  = true
 }
 
 # Allowed Team（オプション）

--- a/infra/modules/vercel/variables.tf
+++ b/infra/modules/vercel/variables.tf
@@ -90,6 +90,12 @@ variable "enable_deployment_retention" {
   default     = true
 }
 
+variable "skew_protection" {
+  description = "Skew Protection の有効期間（例: '1h', '12h', '1d'）。null で無効化。有効時は Production デプロイが Staged になり手動 Promote が必要"
+  type        = string
+  default     = null
+}
+
 # ========================================
 # Announcement Banner Variables
 # ========================================

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -183,6 +183,12 @@ variable "vercel_enable_deployment_retention" {
   default     = true
 }
 
+variable "vercel_skew_protection" {
+  description = "Skew Protection の有効期間（例: '1h', '12h', '1d'）。null で無効化"
+  type        = string
+  default     = null
+}
+
 # ========================================
 # Vercel Announcement Banner Variables
 # ========================================


### PR DESCRIPTION
## 変更内容

### GitHub Actions ワークフロー修正
- hashicorp/setup-terraform の terraform_wrapper を無効化
- -detailed-exitcode の exit code を GITHUB_OUTPUT に手動書き込み
- 原因: ラッパーが exit code 2 を正しくキャプチャできず、変更があっても apply がスキップされていた

### Vercel プロジェクト設定改善
- skew_protection を変数化（デフォルト無効）
- prioritise_production_builds を有効化
- シークレット環境変数に sensitive フラグを追加