### PR TITLE
tut-life-helperをCORS許可オリジンに追加

### DIFF
--- a/infra/environments/production.tfvars
+++ b/infra/environments/production.tfvars
@@ -24,7 +24,7 @@ db_instance_name = "tut-bus-db-prod"
 db_tier          = "db-f1-micro"
 
 # Application Configuration
-cors_allowed_origins = "https://tut-bus.hekuta.net,https://tut-bus.lcn.ad.jp"
+cors_allowed_origins = "https://tut-bus.hekuta.net,https://tut-bus.lcn.ad.jp,https://tut-life-helper.vercel.app"
 
 # ========================================
 # Cloudflare


### PR DESCRIPTION
## 概要

tut-life-helper から tut-bus API を利用できるようにするため、CORS許可オリジンに `https://tut-life-helper.vercel.app` を追加します。

## 変更内容

- `infra/environments/production.tfvars` の `cors_allowed_origins` に `https://tut-life-helper.vercel.app` を追加

## 補足

tut-life-helper 側で今後バス情報を表示する機能を実装する予定があるため、事前にAPIアクセス用の許可設定を追加するものです。