### PR TITLE
fix: テストコードの gofmt 違反を修正（本番デプロイ停止の解消）

### DIFF
--- a/apps/api/tools/timetable-gen/config_test.go
+++ b/apps/api/tools/timetable-gen/config_test.go
@@ -17,8 +17,8 @@ func TestLookupStation_Canonical(t *testing.T) {
 
 func TestLookupStation_Aliases(t *testing.T) {
 	tests := []struct {
-		input    string
-		wantKey  string
+		input   string
+		wantKey string
 	}{
 		{"八王子みなみ野", "minamino"},
 		{"みなみ野駅", "minamino"},

--- a/apps/api/tools/timetable-gen/mapper_test.go
+++ b/apps/api/tools/timetable-gen/mapper_test.go
@@ -36,9 +36,9 @@ func TestNormalizeTime(t *testing.T) {
 
 func TestParseInterval(t *testing.T) {
 	tests := []struct {
-		input    string
-		wantMin  int
-		wantMax  int
+		input   string
+		wantMin int
+		wantMax int
 	}{
 		{"約3〜5分間隔", 3, 5},
 		{"約3~5分間隔", 3, 5},


### PR DESCRIPTION
## 概要

`gofmt` の桁揃え規則に違反したテストコードにより、API Deploy の Go Format Check が失敗し、**本番デプロイが停止しています**。その解消です。

## 症状

```
Error: フォーマットされていないファイルがあります
tools/timetable-gen/config_test.go
tools/timetable-gen/mapper_test.go
```

以下の run が同一原因で失敗しています。

| run | ワークフロー | ブランチ |
|---|---|---|
| 29734430555 | API Deploy | main |
| 29734244934 | API Deploy | main |
| 29734237899 | API CI | dev |
| 29734162443 | API CI | fix/restore-app-yaml |

## 原因

struct のフィールド桁揃えが `gofmt` の規則と異なっていました。

```go
tests := []struct {
    input    string   // スペースが1つ多い
    wantKey  string
}{
```

`gofmt` は「最長のフィールド名 + スペース1つ」で揃えるため、上記は違反になります。コンパイルも `go test` も通るので、ローカルでは気づけませんでした。

PR #192 でテストを追加した際、`go build` と `go test` は実行しましたが `gofmt -l`（`task api:fmt`）を実行していなかったのが原因です。

## 変更内容

`gofmt -w` を適用しただけで、**差分は空白のみ**です。ロジックの変更はありません。

## 補足：先行して発生していた別の障害について

7/4 と 7/20 09:50 の API Deploy 失敗は本件とは別原因で、`apps/api/app.yaml` が 5/14 のコミット `2690d27` で削除されていたことによるものでした（Deploy ステップの `cp app.yaml app.ci.yaml` が失敗）。

こちらは 7/20 09:56 のコミット `0e58af8` で app.yaml が復活し、既に解消済みです。デプロイ経路が復旧した直後に、本 PR で直す gofmt 違反が次の関門で止めた、という経緯になります。

## 確認事項

- [ ] `gofmt -l .` が何も出力しないこと
- [ ] `go build` / `go test ./...` が通ること
- [ ] マージ後、dev の API CI が通ること

## マージ後のお願い

本番デプロイを復旧させるため、マージ後に `dev → main` の PR 作成をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)