### PR TITLE
ci: timetable-gen 専用 CI を新設し、gofmt をモジュール境界に合わせる

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Go Format Check
         id: fmt
         run: |
-          UNFORMATTED=$(gofmt -l .)
+          UNFORMATTED=$(gofmt -l $(go list -f '{{.Dir}}' ./...))
           if [ -n "$UNFORMATTED" ]; then
             echo "::error::以下のファイルがフォーマットされていません:"
             echo "$UNFORMATTED"

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Go Format Check
         id: fmt
         run: |
-          UNFORMATTED=$(gofmt -l $(go list -f '{{.Dir}}' ./...))
+          UNFORMATTED=$(gofmt -l $(find . -name '*.go' -not -path './tools/*'))
           if [ -n "$UNFORMATTED" ]; then
             echo "::error::以下のファイルがフォーマットされていません:"
             echo "$UNFORMATTED"

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Go Format Check
         id: fmt
         run: |
-          UNFORMATTED=$(gofmt -l $(find . -name '*.go' -not -path './tools/*'))
+          UNFORMATTED=$(gofmt -l $(go list -f '{{range .GoFiles}}{{$.Dir}}/{{.}} {{end}}{{range .TestGoFiles}}{{$.Dir}}/{{.}} {{end}}{{range .XTestGoFiles}}{{$.Dir}}/{{.}} {{end}}' ./...))
           if [ -n "$UNFORMATTED" ]; then
             echo "::error::以下のファイルがフォーマットされていません:"
             echo "$UNFORMATTED"

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Go Format Check
         run: |
-          UNFORMATTED=$(gofmt -l $(find . -name '*.go' -not -path './tools/*'))
+          UNFORMATTED=$(gofmt -l $(go list -f '{{range .GoFiles}}{{$.Dir}}/{{.}} {{end}}{{range .TestGoFiles}}{{$.Dir}}/{{.}} {{end}}{{range .XTestGoFiles}}{{$.Dir}}/{{.}} {{end}}' ./...))
           if [ -n "$UNFORMATTED" ]; then
             echo "::error::フォーマットされていないファイルがあります"
             echo "$UNFORMATTED"

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Go Format Check
         run: |
-          UNFORMATTED=$(gofmt -l .)
+          UNFORMATTED=$(gofmt -l $(go list -f '{{.Dir}}' ./...))
           if [ -n "$UNFORMATTED" ]; then
             echo "::error::フォーマットされていないファイルがあります"
             echo "$UNFORMATTED"

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Go Format Check
         run: |
-          UNFORMATTED=$(gofmt -l $(go list -f '{{.Dir}}' ./...))
+          UNFORMATTED=$(gofmt -l $(find . -name '*.go' -not -path './tools/*'))
           if [ -n "$UNFORMATTED" ]; then
             echo "::error::フォーマットされていないファイルがあります"
             echo "$UNFORMATTED"

--- a/.github/workflows/timetable-gen-ci.yml
+++ b/.github/workflows/timetable-gen-ci.yml
@@ -1,0 +1,56 @@
+# ========================================
+# Timetable Gen CI - Lint / Build / Test
+# ========================================
+# PR時に timetable-gen（apps/api とは別モジュール）の
+# フォーマット・静的解析・ビルド・テストを実行
+
+name: 'Timetable Gen CI'
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'apps/api/tools/timetable-gen/**'
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: apps/api/tools/timetable-gen
+
+jobs:
+  ci:
+    name: 'Lint & Build & Test'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: apps/api/tools/timetable-gen/go.mod
+          cache-dependency-path: apps/api/tools/timetable-gen/go.sum
+
+      - name: Download Dependencies
+        run: go mod download
+
+      - name: Go Format Check
+        run: |
+          UNFORMATTED=$(gofmt -l .)
+          if [ -n "$UNFORMATTED" ]; then
+            echo "::error::以下のファイルがフォーマットされていません:"
+            echo "$UNFORMATTED"
+            exit 1
+          fi
+
+      - name: Go Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build -o /dev/null .
+
+      - name: Test
+        run: go test -v -race ./...


### PR DESCRIPTION
## 背景

PR #200 で発覚した gofmt 事故の根本原因を修正する。

`apps/api/tools/timetable-gen` は独自の `go.mod` を持つ別モジュールで、`apps/api` 側の `go vet` / `go build` / `go test` はこのディレクトリを見に行かない（Go のモジュール境界による正しい挙動）。

一方 `gofmt` はモジュールを意識しない単純なファイル走査ツールのため、`apps/api` 側のフォーマットチェックだけがこの境界を無視し、`tools/` 配下のファイルも巻き込んでいた。結果として:

- `timetable-gen` 単独の変更では `api-ci.yml` が起動しない（`paths` に `!apps/api/tools/**` があるため）ので、**PR の時点では何もチェックされない**
- `apps/api` 側の変更と一緒に `tools/` の変更が main に入ると、`gofmt` だけが不意打ちで検出し、他のチェックとタイミングがズレて Deploy を止める（今回の事故）

## 対応

1. **`timetable-gen-ci.yml` を新設** — PR 時に `timetable-gen` 単体で `gofmt` / `go vet` / `go build` / `go test` を実行する（`tools/seedlint` が `migration-ci.yml` で受けている扱いと同等にする）
2. **`api-ci.yml` / `api-deploy.yml` の `gofmt` をモジュール境界に合わせる** — `gofmt -l .` → `gofmt -l $(go list -f '{{.Dir}}' ./...)` に変更し、`go vet`/`go build`/`go test` と同じ範囲だけを見るようにする

## 確認事項

- [ ] `timetable-gen-ci.yml` が `apps/api/tools/timetable-gen/**` の変更で正しく起動すること
- [ ] `api-ci.yml` / `api-deploy.yml` の Go Format Check が `apps/api` 本体のみを対象にすること（tools を誤検出しないこと）
- [ ] 既存の `apps/api` の gofmt/vet/build/test が引き続き通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)